### PR TITLE
gnome: Add pinentry-gnome3

### DIFF
--- a/src/packages/DE/GNOME/gnome.sh
+++ b/src/packages/DE/GNOME/gnome.sh
@@ -16,6 +16,7 @@ apt-get install -y \
   dconf-editor \
   fonts-otf-abattis-cantarell \
   gnome-backgrounds \
+  pinentry-gnome3 \
   yelp \
   gnome-system-monitor \
   gnome-logs \


### PR DESCRIPTION
This package is needed to display the password for some scenarios. For example, entering the ssh password during commit in VSC